### PR TITLE
ci: filter out meson-private with filter-sarif

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,3 +67,19 @@ jobs:
         uses: github/codeql-action/analyze@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
         with:
           category: "/language:cpp"
+          upload: false
+          output: sarif-results
+
+      - name: Filter out meson-internal test files
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -build/meson-private/**/testfile.c
+          input: sarif-results/cpp.sarif
+          output: sarif-results/cpp.sarif
+
+      - name: Upload CodeQL results to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarif-results/cpp.sarif
+          category: "/language:cpp"


### PR DESCRIPTION
The meson setup process generates a large amount of test files, which suffer seemingly from style/security issues.

Filter those out so the resulting report contains only relevant issues. This change is, ahem inspired, by the RAUC team so all credit goes to them - see https://github.com/rauc/rauc/pull/1357